### PR TITLE
Update operators according to C++ idioms

### DIFF
--- a/include/clusteringutility.h
+++ b/include/clusteringutility.h
@@ -88,7 +88,7 @@ T ClusteringUtility<T>::KMeansFixedK(Matrix<T> X, int rounds, int K, vector<int>
 
             }
 
-            if (fabs(currentRound - last) < 1e-12)
+            if (fabs(currentRound - last) < 1e-16)
                 break;
             last = currentRound;
 
@@ -103,7 +103,7 @@ T ClusteringUtility<T>::KMeansFixedK(Matrix<T> X, int rounds, int K, vector<int>
                         crtMean = crtMean + X[i];
                         numberElements += 1;
                     }
-                crtMean = crtMean / numberElements;
+                crtMean = crtMean / (1.0L*numberElements);
                 Matrix<T> meanK = means[k];
                 ///cout << "Old mean: " << meanK << "\n";
                 ///cout << "New mean: " << crtMean << "\n";

--- a/include/matrixutil.h
+++ b/include/matrixutil.h
@@ -149,7 +149,7 @@ void MatrixUtil<T>::HouseholderQR(Matrix<T> A, Matrix<T> &Q, Matrix<T> &R)
         vk.set(1,0, vk.get(1,0) + sign(x.get(1, 0)) * x.frobeniusNorm());
         vk.normalize();
         Matrix<T> aux = A(k, m, k, n);
-        aux = vk*(vk.transpose()*aux) * (-2);
+        aux = vk*(vk.transpose()*aux) * (-2.0L);
         for (int i = 0; i < aux.numRows(); ++i)
             for (int j = 0; j < aux.numCols(); ++j)
                 A.set(k + i, k + j, A.get(k + i, k + j) + aux.get(i, j));

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ using namespace std;
 
 void unitTest1(int verbose = 0)
 {
-        Matrix<long double> init({
+    Matrix<long double> init({
                               { 1,2,2},
                               {-1,1,2},
                               {-1,0,1},
@@ -327,12 +327,12 @@ void clusteringTest()
 
 int main()
 {
-    ///unitTest1(true);
-    ///unitTest2(true);
-    ///unitTest3(true);
-    ///unitTest4(true);
+    unitTest1(true);
+    unitTest2(true);
+    unitTest3(true);
+    unitTest4(true);
 
-    ///burnTest(true);
+    burnTest(true);
 
     clusteringTest();
 


### PR DESCRIPTION
The matrix.h class operators have been updated according to C++ idioms.
For example, computing c = a * b should be seen as c = a; c *= b;.

Using const references reduced the number of copies being taken and
therefore we get half a second speedup on unit tests.

Test plan: passes all unit tests