### PR TITLE
Change from vector<vector<T>> to valarray<T>

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -252,6 +252,11 @@ void measureError()
         fcout << RL.get(i, i) << endl;/// << MatlabRL.get(i, i) << endl << endl;
     fcout << "\n";
 
+    /// Inverse testing.
+    Matrix<long double> RI;
+    MatrixUtil<long double>::GaussJordan(R, RI);
+    RI *= R * R;
+    assert(MatrixUtil<long double>::compareEquals(RI, R));
 }
 
 int main()


### PR DESCRIPTION
By changing from vector<vector<T>> to valarray<T> we gain significant
speedups due to compiler optimisations on branch predictions and also
fewer cache misses due to contiguous memory representation. The time
performance improved by a factor of 2 to 4 depending on the level of
compiler optimisations which can be achieved.

Test plan: passes all unit tests, textbook result still holds.

Future issues: HouseholderQR looks buggy.