### PR TITLE
Numerical Stability Benchmark

### DIFF
--- a/include/matrixutil.h
+++ b/include/matrixutil.h
@@ -123,7 +123,6 @@ void MatrixUtil<T>::GaussJordan(Matrix<T> A, Matrix<T> &AI)
         }
     }
     /// We are now in an upper unitriangular shape
-
     for (int i = (int)A.numRows() - 1; i >= 0; --i)
         for (int j = i - 1; j >= 0; --j) {
             AI.addToRow(j, AI[i] * (-A.get(j, i)));

--- a/main.cpp
+++ b/main.cpp
@@ -285,17 +285,105 @@ void unitTest5(int verbose = 0)
     assert(MatrixUtil<long double>::compareEquals(A, init));
 }
 
+void measurePrecisionATAI()
+{
+    Matrix<long double> A, b, Q, R, QL, RL, ATA, ATAI, xmatlab;
+
+    MatrixUtil<long double>::Reader(A, string("precisionA.in"));
+    MatrixUtil<long double>::Reader(b, string("precisionB.in"));
+
+    ATA = A.transpose() * A;
+    MatrixUtil<long double>::GaussJordan(ATA, ATAI);
+    ///MatrixUtil<long double>::Reader(ATAI, string("precisionATAI.in"));
+
+    Matrix<long double> x = ATAI * (A.transpose() * b);
+    cout << setprecision(30) << fixed;
+    cout << "My      answer: " << x.get(14, 0) << endl;
+    MatrixUtil<long double>::Reader(xmatlab, string("precisionTest1.in"));
+    cout << "Matlab  answer: " << xmatlab.get(14,0) << endl;
+    cout << "Correct answer: 1";
+}
+
+void measurePrecisionMGS()
+{
+    Matrix<long double> A, b, Q, R, RI, xmatlab;
+
+    MatrixUtil<long double>::Reader(A, string("precisionA.in"));
+    MatrixUtil<long double>::Reader(b, string("precisionB.in"));
+
+    MatrixUtil<long double>::QRLosslessDecomposition(A, Q, R);
+    MatrixUtil<long double>::GaussJordan(R, RI);
+
+    Matrix<long double> x = RI * Q.transpose() * b;
+    MatrixUtil<long double>::Reader(xmatlab, string("precisionTest2.in"));
+
+    cout << setprecision(30) << fixed;
+    cout << "My      answer: " << x.get(14, 0) << endl;
+    cout << "Matlab  answer: " << xmatlab.get(14,0) << endl;
+    cout << "Correct answer: 1";
+
+}
+
+void measurePrecisionInverse()
+{
+    Matrix<long double> A, b, AI, xmatlab;
+
+    MatrixUtil<long double>::Reader(A, string("precisionA.in"));
+    MatrixUtil<long double>::Reader(b, string("precisionB.in"));
+
+
+    MatrixUtil<long double>::Reader(xmatlab, string("precisionTest3.in"));
+
+    cout << setprecision(30) << fixed;
+    cout << "My      answer: Impossible to invert - not square"<< endl;
+    cout << "Matlab  answer: " << xmatlab.get(14,0) << endl;
+    cout << "Correct answer: 1";
+}
+
+void measurePrecisionMGSE()
+{
+    Matrix<long double> A, b, QE, REI, RE, xmatlab;
+
+    MatrixUtil<long double>::Reader(A, string("precisionA.in"));
+    MatrixUtil<long double>::Reader(b, string("precisionB.in"));
+
+    Matrix<long double> AE(A.numRows(), A.numCols() + 1);
+
+    for (int i = 0; i < A.numCols(); ++i)
+        AE.setColumn(i, A(i));
+    AE.setColumn(A.numCols(), b);
+
+    MatrixUtil<long double>::QRLosslessDecomposition(AE, QE, RE);
+    QE = RE(0, A.numCols() - 1, A.numCols(), A.numCols());
+    RE = RE(0, A.numCols() - 1, 0, A.numCols() - 1);
+
+    MatrixUtil<long double>::GaussJordan(RE, REI);
+
+    Matrix<long double> x = REI * QE;
+
+    MatrixUtil<long double>::Reader(xmatlab, string("precisionTest4.in"));
+
+    cout << setprecision(30) << fixed;
+    cout << "My      answer: " << x.get(14, 0) << endl;
+    cout << "Matlab  answer: " << xmatlab.get(14,0) << endl;
+    cout << "Correct answer: 1";
+}
+
 int main()
 {
     ///unitTest1(true);
     ///unitTest2(true);
     ///unitTest3(true);
     ///unitTest4(true);
-    unitTest5(true);
+    ///unitTest5(true);
 
 
     ///clusteringTest();
     ///measureError();
+    ///measurePrecisionATAI();
+    ///measurePrecisionMGS();
+    measurePrecisionMGSE();
+    ///measurePrecisionInverse(); /// matlab turns to best fit as inverse doesn't exist.
 
 
     return 0;


### PR DESCRIPTION
The algorithms have been benchmarked (apart from the buggy
triangularisation). The results are the following:

(A^TA)^-1 A^T b  =  x was the worst approximation, leaving an error of
1e0 which is identical to the matlab's precision.

R^-1 Q^T b = x  where [Q,R] = QRLoslessDecoposition(A, Q, R) turned out
to have a precision of 1e-4 which was to be expected. Matlab's precision
still did not improve, obtaining 1e-1.

RE^-1 QE = x where [QE, RE] = QRLoslessDecomposition([A b], QE, RE)
turned out to beat the book expected result of 1e-6, obtaining 1e-7
accuracy while matlab's implementation has a more accurate result 1e-8.
I believe that some subtle optimisations happened in matlab.

Note, my class can't invert a non squared matrix, however, matlab can
approximate and has a 1e-6 solution - which matches the textbook
predicted best answer.

Note, the textbook mentions that 1e-7 is the best possible result (at
that time) provable by SVD decomposition analysis as being better than
any of the above. This is beyond the scope of the project as it requires
analysis on eigendecomposition in numerical stable ways.