### PR TITLE
optimise lossless qr factorisation

### DIFF
--- a/include/matrixutil.h
+++ b/include/matrixutil.h
@@ -88,13 +88,14 @@ void MatrixUtil<T>::QRLosslessDecomposition(Matrix<T> A, Matrix<T> &Q, Matrix<T>
     Q = Matrix<T>(m, n);
     R = Matrix<T>(n, n);
     Matrix<T> V = A;
-    for (int i = 0; i < n; ++i) {
-        R.set(i, i, V(i).frobeniusNorm());
-        Q.setColumn(i, V(i) / R.get(i, i));
-        for (int j = i + 1; j < n; ++j) {
+
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < j; ++i) {
             R.set(i, j, (Q(i).transpose() * V(j)).get(0, 0));
             V.setColumn(j, V(j) - Q(i) * R.get(i, j));
         }
+        R.set(j, j, V(j).frobeniusNorm());
+        Q.setColumn(j, V(j) / R.get(j, j));
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -551,7 +551,7 @@ void testFitNoisyPolynomial()
         }
         ///A.print(15);
         ///cerr << "\n---------------------------\n";
-        MatrixUtil<long double>::LeastSquaresQR(A, b, x, false);
+        MatrixUtil<long double>::LeastSquaresQR(A, b, x, true);
         Matrix<long double> y = A*x - b;
         cout << x << "\n Error: ";
         cout << setprecision(10) << fixed;


### PR DESCRIPTION
having done the maths, I was able to tell what the exact difference
between the algorithms is and rewrote the algorithm in the "backwards"
style rather than forwards - which saved significant time (from 380ms to
160 ms the total error measurement time)